### PR TITLE
Hotfix de bugs de sesión vitales

### DIFF
--- a/Saca la Bici/Data/Models/Network/SessionAPIService.swift
+++ b/Saca la Bici/Data/Models/Network/SessionAPIService.swift
@@ -99,7 +99,7 @@ class SessionAPIService: NSObject {
         }
     }
     
-    func iniciarSesion(UserDatos: User, URLUsername: URL) async -> Int? {
+    func iniciarSesion(UserDatos: User, URLUsername: URL, url: URL) async -> Int? {
         do {
             var usuarioOEmail = UserDatos.emailorUsername
             
@@ -127,14 +127,34 @@ class SessionAPIService: NSObject {
                 "Content-Type": "application/json"
             ]
             
-            print(headers)
-            // Falta hacer la llamada al back para mostrar info despues de iniciar sesion.
+            /* Para checar si el backend esta funcionando.
+             Despues esto se cambia por la función de consultar actividades */
             
-            return 200 // Código de éxito, o el código que desees manejar
+            let taskRequest = session.request(url, method: .get, headers: headers).validate()
+            let response = await taskRequest.serializingData().response
+            
+            let statusCode = response.response?.statusCode
+            
+            switch response.result {
+            case .success:
+                    return statusCode
+            case let .failure(error):
+                // Ya que dio error, sacas al usuario de la sesion de Firebase
+                try Auth.auth().signOut()
+                debugPrint(error.localizedDescription)
+                
+                // Imprimir el cuerpo de la respuesta en caso de error
+                if let data = response.data {
+                    let errorResponse = String(decoding: data, as: UTF8.self)
+                    print("\(errorResponse)")
+                }
+                
+                return statusCode
+            }
         } catch {
             // Manejo de errores de inicio de sesión
             print("Error al iniciar sesión: \(error.localizedDescription)")
-            return nil // Error, devuelve nil o el código de error correspondiente
+            return 1 // Error, devuelve nil o el código de error correspondiente
         }
     }
     

--- a/Saca la Bici/Data/Models/Repositories/SessionRepository.swift
+++ b/Saca la Bici/Data/Models/Repositories/SessionRepository.swift
@@ -50,7 +50,9 @@ class SessionRepository: SessionAPIProtocol {
     
     // Tomar en cuenta la llamada al back para mostrar info
     func iniciarSesion(UserDatos: User) async -> Int? {
-        return await sessionService.iniciarSesion(UserDatos: UserDatos, URLUsername: URL(string: "\(Api.base)\(Api.Routes.session)/getUserEmail")!)
+        return await sessionService.iniciarSesion(UserDatos: UserDatos,
+                                                  URLUsername: URL(string: "\(Api.base)\(Api.Routes.session)/getUserEmail")!,
+                                                  url: URL(string: "\(Api.base)")!)
     }
     
     func checarPerfilBackend() async throws -> Response {

--- a/Saca la Bici/Framework/ViewModels/Session/LoginViewModel.swift
+++ b/Saca la Bici/Framework/ViewModels/Session/LoginViewModel.swift
@@ -45,8 +45,11 @@ class LoginViewModel: ObservableObject {
         
         let responseStatus = await self.loginRequirement.iniciarSesion(UserDatos: UserData)
         
-        if responseStatus != 200 {
+        if responseStatus == 1 {
             self.messageAlert = "El usuario o contraseña ingresada es incorrecta. Favor de intentarlo de nuevo."
+            self.showAlert = true
+        } else if responseStatus != 200 {
+            self.messageAlert = "Hubo un error al procesar el inicio se sesión.  Favor de intentarlo de nuevo."
             self.showAlert = true
         }
     }
@@ -126,3 +129,4 @@ class LoginViewModel: ObservableObject {
         }
     }
 }
+

--- a/Saca la Bici/Framework/ViewModels/Session/LoginViewModel.swift
+++ b/Saca la Bici/Framework/ViewModels/Session/LoginViewModel.swift
@@ -49,7 +49,7 @@ class LoginViewModel: ObservableObject {
             self.messageAlert = "El usuario o contraseña ingresada es incorrecta. Favor de intentarlo de nuevo."
             self.showAlert = true
         } else if responseStatus != 200 {
-            self.messageAlert = "Hubo un error al procesar el inicio se sesión.  Favor de intentarlo de nuevo."
+            self.messageAlert = "Hubo un error al procesar el inicio se sesión. Favor de intentarlo de nuevo."
             self.showAlert = true
         }
     }
@@ -129,4 +129,3 @@ class LoginViewModel: ObservableObject {
         }
     }
 }
-

--- a/Saca la Bici/Framework/ViewModels/Session/SessionManager.swift
+++ b/Saca la Bici/Framework/ViewModels/Session/SessionManager.swift
@@ -34,13 +34,16 @@ class SessionManager: ObservableObject {
             DispatchQueue.main.async {
                 self?.isFireBaseAuthenticated = user != nil
                 if let user = user {
-                    if self?.isExternalSignIn(user: user) == true {
+                    let isRegistrationComplete = UserDefaults.standard.bool(forKey: "isRegistrationComplete")
+                    if isRegistrationComplete || self?.isExternalSignIn(user: user) == true {
                         self?.isAuthenticated = true
                         self?.checkProfileCompleteness()
                     }
                 } else {
+                    self?.isAuthenticated = false
                     self?.isProfileComplete = false
                     self?.isLoading = false
+                    UserDefaults.standard.set(false, forKey: "isRegistrationComplete")
                 }
             }
         }
@@ -116,6 +119,7 @@ class SessionManager: ObservableObject {
             isProfileComplete = false
             isAuthenticated = false
             isFireBaseAuthenticated = false
+            UserDefaults.standard.set(false, forKey: "isRegistrationComplete")
         } catch let signOutError as NSError {
             print("Error signing out: %@", signOutError)
         }

--- a/Saca la Bici/Framework/Views/Session/LoginView.swift
+++ b/Saca la Bici/Framework/Views/Session/LoginView.swift
@@ -75,6 +75,9 @@ struct LoginView: View {
                                     if loginViewModel.showAlert != true {
                                         sessionManager.isAuthenticated = true
                                         sessionManager.isProfileComplete = true
+                                        UserDefaults.standard.set(true, forKey: "isRegistrationComplete")
+                                    } else {
+                                        UserDefaults.standard.set(false, forKey: "isRegistrationComplete")
                                     }
                                 }
                             }

--- a/Saca la Bici/Framework/Views/Session/SignUpStep3View.swift
+++ b/Saca la Bici/Framework/Views/Session/SignUpStep3View.swift
@@ -69,6 +69,9 @@ struct SignUpStep3View: View {
                                     if signUpViewModel.showAlert != true {
                                         sessionManager.isAuthenticated = true
                                         sessionManager.isProfileComplete = true
+                                        UserDefaults.standard.set(true, forKey: "isRegistrationComplete")
+                                    } else {
+                                        UserDefaults.standard.set(false, forKey: "isRegistrationComplete")
                                     }
                                 }
                             }


### PR DESCRIPTION
Se arreglaron dos bugs que se encontraron en session: 
1. Se podia iniciar sesión aunque el backend no estaba conectado
2. Si se cerraba la app sin cerrar sesión cuando se inicio sesión con correo, no avanzaba de la loading screen. Pueden probar estos dos escenarios?